### PR TITLE
Add test-integration.yaml for GitHub Actions

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -1,0 +1,19 @@
+name: test-integration
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Init environment
+        run: cd support/docker && ./init-test.sh
+      - name: Run tests
+        run: ./support/docker/composer.sh check
+        env:
+          SYMFONY_ENV: test
+      - name: Show log on failure
+        if: failure()
+        run:  |
+          cd support/docker && docker-compose exec -T php-fpm.readid.stepup.example.com cat var/logs/test/test.log

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 Stepup-ReadID
 ===================
 
-<a href="#">
-    <img src="https://travis-ci.org/OpenConext/Stepup-ReadID.svg?branch=develop" alt="build:">
-</a></br>
+![test-integration](https://github.com/OpenConext/Stepup-ReadID/workflows/test-integration/badge.svg)
 
 IdP for ReadId integration 
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ To run all required test you can run the following commands from the dev env:
 
 Every part can be run separately. Check "scripts" section of the composer.json file for the different options.
 
+GitHub Actions are used as CI environment. The `composer check` is performed and should pass in order to get a 'green' build.
+
 Release instructions
 =====================
 

--- a/support/docker/composer.sh
+++ b/support/docker/composer.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 cd $(dirname "$0")
-docker-compose exec -T -u=$(id -u) php-fpm.readid.stepup.example.com composer $@
+docker-compose exec -T php-fpm.readid.stepup.example.com composer $@

--- a/support/docker/init-test.sh
+++ b/support/docker/init-test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+uid=$(id -u)
+gid=$(id -g)
+
+printf "UID=${uid}\nGID=${gid}\nCOMPOSE_PROJECT_NAME=readid" > .env
+
+docker-compose up -d
+
+docker-compose exec -T php-fpm.readid.stepup.example.com bash -c '
+  composer install --prefer-dist -n -o && \
+  ./bin/console cache:clear --env=test
+'


### PR DESCRIPTION
A test-init script was added that prepares the test environment. For now, no noteworthy checks are being run. But this should change when development starts.

The integration should run on push and pull request creation.